### PR TITLE
release: add homebrew bump step

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -120,3 +120,13 @@ jobs:
           draft: false
           prerelease: false
           token: ${{ secrets.GH_PAT }}
+
+  homebrew:
+    needs: [build-linux, build-windows, build-mac]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mislav/bump-homebrew-formula-action@v2
+        with:
+          formula-name: fastgron
+        env:
+          COMMITTER_TOKEN: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
using https://github.com/mislav/bump-homebrew-formula-action to automate homebrew release